### PR TITLE
権限追加

### DIFF
--- a/src/app/Exceptions/ForbiddenException.php
+++ b/src/app/Exceptions/ForbiddenException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class ForbiddenException extends Exception
+{
+
+}

--- a/src/app/Exceptions/Handler.php
+++ b/src/app/Exceptions/Handler.php
@@ -44,6 +44,9 @@ class Handler extends ExceptionHandler
 
     public function render($request, Exception|Throwable $e)
     {
+        if ($e instanceof ForbiddenException) {
+            return redirect('/articles')->with('message', $e->getMessage());
+        }
         if ($e instanceof NotFoundException) {
             abort('404');
         }

--- a/src/app/Http/Controllers/ArticleController.php
+++ b/src/app/Http/Controllers/ArticleController.php
@@ -95,22 +95,14 @@ class ArticleController extends Controller
     /**
      * Show the form for editing the specified resource.
      *
-     * @param Request $request
      * @param int $id
      * @return Response
      */
-    public function edit($request, $id)
+    public function edit($id)
     {
-        $user = $request->user();
-        if (is_null($user)) {
-            throw new ForbiddenException('ログインが必要です');
-        }
         $article = $this->articleService->findById($id);
         if (!$article) {
             throw new NotFoundException();
-        }
-        if ($user->id !== $article->user->id) {
-            throw new ForbiddenException('他のユーザーの投稿は、編集、更新、削除できません');
         }
         $tags = $this->tagService->findAll();
         return view('articles/edit', compact('article', 'tags'));

--- a/src/app/Http/Kernel.php
+++ b/src/app/Http/Kernel.php
@@ -63,5 +63,6 @@ class Kernel extends HttpKernel
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'checkSignin' => \App\Http\Middleware\CheckSignin::class,
     ];
 }

--- a/src/app/Http/Middleware/CheckSignin.php
+++ b/src/app/Http/Middleware/CheckSignin.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use App\Exceptions\ForbiddenException;
+
+class CheckSignin
+{
+    /**
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (is_null($request->user())) {
+            throw new ForbiddenException('ログインが必要です');
+        }
+
+        return $next($request);
+    }
+}

--- a/src/app/Services/ArticleService.php
+++ b/src/app/Services/ArticleService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Entities\ArticleEntity;
+use App\Exceptions\ForbiddenException;
 use App\Exceptions\NotFoundException;
 use App\Repositories\ArticleRepositoryInterface;
 use Exception;
@@ -53,12 +54,16 @@ class ArticleService
         string $title,
         string $body,
         array  $resources,
-        string $thumbnail_resource
+        string $thumbnail_resource,
+        int    $user_id
     ): bool
     {
         $article = $this->articleRepositoryInterface->findById($id);
         if (!$article) {
             throw new NotFoundException();
+        }
+        if ($user_id !== $article->user->id) {
+            throw new ForbiddenException('他のユーザーの投稿は、編集、更新、削除できません');
         }
         $is_update_success = $this->articleRepositoryInterface->update(
             $id,
@@ -73,11 +78,14 @@ class ArticleService
         return true;
     }
 
-    public function destroy(int $id): bool
+    public function destroy(int $id, int $user_id): bool
     {
         $article = $this->articleRepositoryInterface->findById($id);
         if (!$article) {
             throw new NotFoundException();
+        }
+        if ($user_id !== $article->user->id) {
+            throw new ForbiddenException('他のユーザーの投稿は、編集、更新、削除できません');
         }
         $is_deleted_success = $this->articleRepositoryInterface->destroy($id);
         if (!$is_deleted_success) {

--- a/src/resources/views/articles/articleList.blade.php
+++ b/src/resources/views/articles/articleList.blade.php
@@ -5,15 +5,23 @@
     <title>記事</title>
 </head>
 <body>
+@if (session('message'))
+    <div style="color:red">
+        {{ session('message') }}
+    </div>
+@endif
 @if (Auth::user())
     こんにちは、{{Auth::user()->name}}さん
 @endif
 @foreach ($articles as $article)
     <h3>{{ $article->id}}</h3>
-    <img src="/img/{{ $article->thumbnail_image_name }}" alt="" style="width:200px; height:200px">
+    <img src="/img/{{ $article->thumbnail_image_name }}" alt=""
+         style="width:200px; height:200px">
     <h3>{{ $article->title }}</h3>
     <p>書いた人: {{ $article->user->name }}</p>
-    <button type="button" class="btn btn-info" onclick=location.href="/articles/{{ $article->id }}">More</button>
+    <button type="button" class="btn btn-info"
+            onclick=location.href="/articles/{{ $article->id }}">More
+    </button>
     <form action="/articles/{{ $article->id }}" method="post">
         @method('DELETE')
         @csrf

--- a/src/resources/views/articles/show.blade.php
+++ b/src/resources/views/articles/show.blade.php
@@ -5,6 +5,9 @@
     <title>記事</title>
 </head>
 <body>
+@if (Auth::user())
+    こんにちは、{{Auth::user()->name}}さん
+@endif
 <h3>{{ $article->id }}</h3>
 <img src="/img/{{ $article->thumbnail_image_name }}" alt="" style="width:200px; height:200px">
 @foreach($article->article_image as $image)

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -19,11 +19,14 @@ use App\Http\Controllers\AuthController;
 // Article
 Route::get('/articles', [ArticleController::class, 'index']);
 Route::get('/articles/new', [ArticleController::class, 'new']);
-Route::post('/articles', [ArticleController::class, 'create']);
 Route::get('/articles/{id}', [ArticleController::class, 'show']);
-Route::get('/articles/{id}/edit', [ArticleController::class, 'edit']);
-Route::patch('/articles/{id}', [ArticleController::class, 'update']);
-Route::delete('/articles/{id}', [ArticleController::class, 'destroy']);
+Route::group(['middleware' => ['checkSignin']], function () {
+    Route::post('/articles', [ArticleController::class, 'create']);
+    Route::get('/articles/{id}/edit', [ArticleController::class, 'edit']);
+    Route::patch('/articles/{id}', [ArticleController::class, 'update']);
+    Route::delete('/articles/{id}', [ArticleController::class, 'destroy']);
+});
+
 
 // Auth
 Route::get('/auth/signup', [AuthController::class, 'viewSignup']);


### PR DESCRIPTION
## 要件
- [x]  ユーザー機能を追加後は、ユーザーログイン中でないと投稿できない状態にすること。「Submit」ボタンをおすと「ログインが必要です」のエラーメッセージを表示させる。
- [x]  投稿の編集、更新、削除は他のユーザーは行えない状態にすること。他人の投稿を編集、更新、削除するためのURLを叩くと、投稿一覧ページに遷移して「他のユーザーの投稿は、編集、更新、削除できません」のエラーメッセージを表示させる。
- [x]  投稿一覧と詳細に、それぞれどのユーザーが投稿したかわかるように、投稿したユーザーの名前が表示されること。

## 動作検証
- 未ログインユーザーが作成できないことを確認

https://user-images.githubusercontent.com/42329711/174957121-f2cbf07d-d9de-46be-b795-cc1eeea48016.mov

- 未ログインユーザーが削除、編集できないことを確認
https://user-images.githubusercontent.com/42329711/174956609-41b0953a-3b9c-453e-8347-8ad824261fb6.mov


- ログインユーザーが他人記事の削除、編集できないことを確認
- 一覧、詳細画面にログインしているユーザーの名前が表示されることを確認

https://user-images.githubusercontent.com/42329711/174956494-e2e0ffc1-a187-4129-ac6b-173f015fc121.mov
